### PR TITLE
Add missing vertical bar symbol for a keyword

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -96,7 +96,7 @@ char* C_HL_keywords[] = {
 	"switch", "if", "while", "for", "break", "continue", "return", "else",
 	"struct", "union", "typedef", "static", "enum", "class", "case",
 	
-	"int|", "long|", "double|", "float|", "char|", "unsigned|", "signed",
+	"int|", "long|", "double|", "float|", "char|", "unsigned|", "signed|",
 	"void|", NULL
 };
 struct editorSyntax HLDB[] = {


### PR DESCRIPTION
I just cast a random glance at your code and accidentally noticed this error. Also the github editor automagically added a newline at the end of file, but that's for good because it's conventional (at least in Unix'es).